### PR TITLE
Bat Files: Change batch file to compare start and end time in entirety, not just seconds

### DIFF
--- a/OGP/ogp_agent.pl
+++ b/OGP/ogp_agent.pl
@@ -448,7 +448,8 @@ sub create_screen_cmd_loop
 	# Create batch file that will launch the process and store PID which will be used for killing later
 	open (SERV_START_BAT_SCRIPT, '>', $server_start_batfile);
 	
-	my $batch_server_command = ":TOP" . "\r\n";
+	my $batch_server_command = "@ECHO OFF" . "\r\n"
+	. ":TOP" . "\r\n";
 	
 	if(defined $envVars && $envVars ne ""){
 		$batch_server_command .= $envVars;
@@ -457,15 +458,14 @@ sub create_screen_cmd_loop
 	$batch_server_command .= "set STARTTIME=%time%" . "\r\n"
 	. "start " . $priority . " " . $affinity . " /wait " . $exec_cmd . "\r\n"
 	. "set ENDTIME=%time%" . "\r\n"
-	. "set /A STARTTIME=(1%STARTTIME:~0,2%-100)*360000 + (1%STARTTIME:~3,2%-100)*6000 + (1%STARTTIME:~6,2%-100)*100 + (1%STARTTIME:~9,2%-100)" . "\r\n"
-	. "set /A ENDTIME=(1%ENDTIME:~0,2%-100)*360000 + (1%ENDTIME:~3,2%-100)*6000 + (1%ENDTIME:~6,2%-100)*100 + (1%ENDTIME:~9,2%-100)" . "\r\n"
-	. "set /A DURATION=%ENDTIME%-%STARTTIME%" ."\r\n"
-	. "if %ENDTIME% LSS %STARTTIME% set /A DURATION=%STARTTIME%-%ENDTIME%" ."\r\n"
-	. "set /A DURATIONH=%DURATION% / 360000" ."\r\n"
-	. "set /A DURATIONM=(%DURATION% - %DURATIONH%*360000) / 6000" ."\r\n"
-	. "set /A DURATIONS=(%DURATION% - %DURATIONH%*360000 - %DURATIONM%*6000) / 100" ."\r\n"
+	. "set \"end=!ENDTIME:%time:~8,1%=%%100)*100+1!\"  &  set \"start=!STARTTIME:%time:~8,1%=%%100)*100+1!\"" . "\r\n"
+	. "set /A \"elap=((((10!end:%time:~2,1%=%%100)*60+1!%%100)-((((10!start:%time:~2,1%=%%100)*60+1!%%100)\"" . "\r\n"
+	. "set /A \"cc=elap%%100+100,elap/=100,ss=elap%%60+100,elap/=60,mm=elap%%60+100,hh=elap/60+100\"" . "\r\n"
+	. "set hour=%hh:~1%" . "\r\n"
+	. "set minute=%mm:~1%" . "\r\n"
+	. "set second=%ss:~1%" . "\r\n"
 	. "if exist SERVER_STOPPED exit" . "\r\n"
-	. "if %DURATIONS% lss 15 exit" . "\r\n"
+	. "IF \"%hour%\" == \"00\" IF \"%minute%\" == \"00\" IF %second% lss 15 exit" . "\r\n"
 	. "goto TOP" . "\r\n";
 	
 	print SERV_START_BAT_SCRIPT $batch_server_command;

--- a/OGP/ogp_agent.pl
+++ b/OGP/ogp_agent.pl
@@ -456,11 +456,17 @@ sub create_screen_cmd_loop
 	
 	$batch_server_command .= "set starttime=%time%" . "\r\n"
 	. "start " . $priority . " " . $affinity . " /wait " . $exec_cmd . "\r\n"
-	. "set endtime=%time%" . "\r\n" 
-	. "set /a secs=%endtime:~6,2%" . "\r\n" 
+	. "set endtime=%time%" . "\r\n"
+	. "set /a starttimestamp=\"%starttime:~0,2%%starttime:~3,2%\"" . "\r\n"
+	. "set /a endtimestamp=\"%endtime:~0,2%%endtime:~3,2%\"" . "\r\n"
+	. "set /a secs=%endtime:~6,2%" . "\r\n"
 	. "set /a secs=%secs%-%starttime:~6,2%" . "\r\n"
 	. "if exist SERVER_STOPPED exit" . "\r\n"
-	. "if %secs% lss 15 exit" . "\r\n"
+	. "if %secs% lss 15 (" . "\r\n"
+	. "\tif \"%starttimestamp%\" == \"%endtimestamp%\" ( " ."\r\n"
+	. "\t\texit" ."\r\n"
+	. "\t)" ."\r\n"
+	. ")" ."\r\n"
 	. "goto TOP" . "\r\n";
 	
 	print SERV_START_BAT_SCRIPT $batch_server_command;

--- a/OGP/ogp_agent.pl
+++ b/OGP/ogp_agent.pl
@@ -448,7 +448,8 @@ sub create_screen_cmd_loop
 	# Create batch file that will launch the process and store PID which will be used for killing later
 	open (SERV_START_BAT_SCRIPT, '>', $server_start_batfile);
 	
-	my $batch_server_command = "@ECHO OFF" . "\r\n"
+	my $batch_server_command = "\@echo off" . "\r\n"
+	. "setlocal EnableDelayedExpansion" . "\r\n"
 	. ":TOP" . "\r\n";
 	
 	if(defined $envVars && $envVars ne ""){

--- a/OGP/ogp_agent.pl
+++ b/OGP/ogp_agent.pl
@@ -454,19 +454,18 @@ sub create_screen_cmd_loop
 		$batch_server_command .= $envVars;
 	}
 	
-	$batch_server_command .= "set starttime=%time%" . "\r\n"
+	$batch_server_command .= "set STARTTIME=%time%" . "\r\n"
 	. "start " . $priority . " " . $affinity . " /wait " . $exec_cmd . "\r\n"
-	. "set endtime=%time%" . "\r\n"
-	. "set /a starttimestamp=\"%starttime:~0,2%%starttime:~3,2%\"" . "\r\n"
-	. "set /a endtimestamp=\"%endtime:~0,2%%endtime:~3,2%\"" . "\r\n"
-	. "set /a secs=%endtime:~6,2%" . "\r\n"
-	. "set /a secs=%secs%-%starttime:~6,2%" . "\r\n"
+	. "set ENDTIME=%time%" . "\r\n"
+	. "set /A STARTTIME=(1%STARTTIME:~0,2%-100)*360000 + (1%STARTTIME:~3,2%-100)*6000 + (1%STARTTIME:~6,2%-100)*100 + (1%STARTTIME:~9,2%-100)" . "\r\n"
+	. "set /A ENDTIME=(1%ENDTIME:~0,2%-100)*360000 + (1%ENDTIME:~3,2%-100)*6000 + (1%ENDTIME:~6,2%-100)*100 + (1%ENDTIME:~9,2%-100)" . "\r\n"
+	. "set /A DURATION=%ENDTIME%-%STARTTIME%" ."\r\n"
+	. "if %ENDTIME% LSS %STARTTIME% set /A DURATION=%STARTTIME%-%ENDTIME%" ."\r\n"
+	. "set /A DURATIONH=%DURATION% / 360000" ."\r\n"
+	. "set /A DURATIONM=(%DURATION% - %DURATIONH%*360000) / 6000" ."\r\n"
+	. "set /A DURATIONS=(%DURATION% - %DURATIONH%*360000 - %DURATIONM%*6000) / 100" ."\r\n"
 	. "if exist SERVER_STOPPED exit" . "\r\n"
-	. "if %secs% lss 15 (" . "\r\n"
-	. "\tif \"%starttimestamp%\" == \"%endtimestamp%\" ( " ."\r\n"
-	. "\t\texit" ."\r\n"
-	. "\t)" ."\r\n"
-	. ")" ."\r\n"
+	. "if %DURATIONS% lss 15 exit" . "\r\n"
 	. "goto TOP" . "\r\n";
 	
 	print SERV_START_BAT_SCRIPT $batch_server_command;


### PR DESCRIPTION
Checking the seconds for is the server has been running for > 15 seconds is incredibly unreliable, especially if you have game servers that automatically restart on a schedule.

This change records the start hour and minute and uses those too to determine if the server has been up < 15 seconds

Fail Case:
Arma server which starts at 15:00:01 on a 3 hourly restart schedule. Server auto-restarts itself at 18:00:02
Since the old code was only checking the seconds, 02-01 = 01, less than 15 seconds, server was never restarted because ogp agent assumed service had been running less than 15 seconds