### PR TITLE
fix rename bug

### DIFF
--- a/OGP/ogp_agent.pl
+++ b/OGP/ogp_agent.pl
@@ -3843,6 +3843,21 @@ sub shell_action
 		}
 		return "1;";
 	}
+	elsif($action eq 'rename')
+	{
+		my($src, $dest) = split(';', $arguments);
+		chomp($src);
+		chomp($dest);
+		if(-d $src)
+		{
+			dirmove($src, $dest);
+		}
+		else
+		{
+			fmove($src, $dest);
+		}
+		return "1;";
+	}
 	elsif($action eq 'copy')
 	{
 		my($src, $dest) = split(';', $arguments);


### PR DESCRIPTION
In the current version, when used when renaming a folder, the folder instead of renaming is moved to the folder with the specified name. This is due to the fact that the rename function uses the API move method in which the folder with the given name is created and the folder to be renamed is moved to it.
https://github.com/OpenGamePanel/OGP-Agent-Linux/blob/39ab98983603505b61db013b87818b75125bfcb5/ogp_agent.pl
```
elsif($action eq 'move')
    {
        my($src, $dest) = split(';', $arguments);
        chomp($src);
        chomp($dest);
        if(-d $src)
        {
            $dest = Path::Class::Dir->new($dest, basename($src));
            dirmove($src, $dest);
        }
        else
        {
            fmove($src, $dest);
        }
        return "1;";
    }